### PR TITLE
Update mix_amount logic in fragment shader

### DIFF
--- a/texture_overlay.gdshader
+++ b/texture_overlay.gdshader
@@ -11,7 +11,10 @@ void vertex(){
 
 void fragment() {
 	// only apply overlay_tex on the fully red parts of the original tiles
-	float mix_amount = floor(COLOR.r);
+	// filter white which is (R=1,G=1,B=1) cause it would otherwise also trigger
+	float mix_amount = step(0.9, COLOR.r)
+	             * (1.0 - step(0.3, COLOR.g))
+	             * (1.0 - step(0.3, COLOR.b));
 	
 	// sample the overlay_tex using worldPos
 	vec4 overlay_color = texture(overlay_tex, world_position * scale);

--- a/texture_overlay.gdshader
+++ b/texture_overlay.gdshader
@@ -13,10 +13,10 @@ void fragment() {
 	// only apply overlay_tex on the fully red parts of the original tiles
 	// filter white which is (R=1,G=1,B=1) cause it would otherwise also trigger
 	// also filter out alpha values for the case that red pixels are next to transparent pixels (cause godot saves the color values in transparent pixel of neighboring color pixels)
-	float mix_amount = step(0.9, COLOR.r)
-	             	* (1.0 - step(0.3, COLOR.g))
-	             	* (1.0 - step(0.3, COLOR.b))
-	             	* step(0.5, COLOR.a);
+	float mix_amount = step(red_threshold, COLOR.r)
+	             	* (1.0 - step(non_red_threshold, COLOR.g))
+	             	* (1.0 - step(non_red_threshold, COLOR.b))
+	             	* step(alpha_threshold, COLOR.a);
 	
 	// sample the overlay_tex using worldPos
 	vec4 overlay_color = texture(overlay_tex, world_position * scale);

--- a/texture_overlay.gdshader
+++ b/texture_overlay.gdshader
@@ -12,9 +12,11 @@ void vertex(){
 void fragment() {
 	// only apply overlay_tex on the fully red parts of the original tiles
 	// filter white which is (R=1,G=1,B=1) cause it would otherwise also trigger
+	// also filter out alpha values for the case that red pixels are next to transparent pixels (cause godot saves the color values in transparent pixel of neighboring color pixels)
 	float mix_amount = step(0.9, COLOR.r)
-	             * (1.0 - step(0.3, COLOR.g))
-	             * (1.0 - step(0.3, COLOR.b));
+	             	* (1.0 - step(0.3, COLOR.g))
+	             	* (1.0 - step(0.3, COLOR.b))
+	             	* step(0.5, COLOR.a);
 	
 	// sample the overlay_tex using worldPos
 	vec4 overlay_color = texture(overlay_tex, world_position * scale);

--- a/texture_overlay.gdshader
+++ b/texture_overlay.gdshader
@@ -4,6 +4,10 @@ uniform sampler2D overlay_tex: repeat_enable, filter_nearest;
 uniform float scale = 0.006944444; // calculated by 1/texture size e.g. 1/144
 varying vec2 world_position;
 
+uniform float red_threshold = 0.9;
+uniform float non_red_threshold = 0.1;
+uniform float alpha_threshold = 0.5;
+
 void vertex(){
 	// calculate the world position for use in the fragment shader
     world_position = (MODEL_MATRIX * vec4(VERTEX, 0.0, 1.0)).xy;


### PR DESCRIPTION
Refine mix_amount calculation to filter out white colors.

Had the issue that white pixels also count towards red since they have red in it. 
That should fix it. 
